### PR TITLE
build: update TypeScript config for monorepo path mapping

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,14 +9,15 @@ import { HashRouter } from 'react-router-dom'
 import { D2I18n } from 'dhis2-semis-types';
 import i18next from '@dhis2/d2-i18n'
 
-function ConfigirationsPage({ i18n }: { i18n: D2I18n }) {
-    const { baseUrl } = useConfig()
+function ConfigirationsPage({ i18n, baseUrl }: { i18n: D2I18n; baseUrl?: string }) {
+    const { baseUrl: localBaseUrl } = useConfig()
     const i18nLocal = i18n ? i18n : i18next
+    const useBaseUrl = baseUrl || localBaseUrl
 
     return (
         // <AppWrapper
         //     i18n={i18nLocal}
-        //     baseUrl={baseUrl}
+        //     baseUrl={useBaseUrl}
         //     dataStoreKey="dataStore/semis/values"
         //     schoolCalendarKey='dataStore/semis/schoolCalendar'
         // >

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,12 @@
       "declarationDir": "./dist/declarations",
       "jsx": "preserve",
       "outDir": "./dist",
-      "rootDir": "./src",
+      "rootDir": "../..",
+      "paths": {
+        "dhis2-semis-components": ["../../libs/components/src"],
+        "dhis2-semis-functions": ["../../libs/functions/src"],
+        "dhis2-semis-types": ["../../libs/types/src"]
+      }
   },
   "exclude": [
       "node_modules",


### PR DESCRIPTION
Add path aliases for internal packages to support monorepo structure. This enables proper module resolution when importing from 'dhis2-semis-components', 'dhis2-semis-functions', and 'dhis2-semis-types' packages during development.